### PR TITLE
Add Time to Discovery to output

### DIFF
--- a/asreviewcontrib/statistics/statistics.py
+++ b/asreviewcontrib/statistics/statistics.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+from builtins import isinstance
 from collections import OrderedDict
 
 import numpy as np
@@ -20,8 +22,6 @@ from asreview.analysis.analysis import Analysis
 from asreview import ASReviewData
 from asreview.utils import pretty_format
 from asreview.config import LABEL_NA
-import json
-from builtins import isinstance
 
 
 class StateStatistics():
@@ -46,6 +46,11 @@ class StateStatistics():
 
     def rrf(self, RRF_value, result_format="percentage"):
         return self.analysis.rrf(RRF_value, x_format=result_format)[0]
+
+    def time_to_discovery(self):
+        ttd_sorted = sorted(self.analysis.avg_time_to_discovery().items(),
+                            key=lambda x: x[1])
+        return {int(i): float(v) for i, v in ttd_sorted}
 
     def loss(self):
         avg_discovery_time = self.analysis.avg_time_to_discovery()
@@ -82,6 +87,7 @@ class StateStatistics():
             "wss": {wss_at: self.wss(wss_at) for wss_at in self.wss_vals},
             "rrf": {rrf_at: self.rrf(rrf_at) for rrf_at in self.rrf_vals},
             "loss": self.loss(),
+            "time_to_discovery": self.time_to_discovery(),
             "general": self.general
         }
 
@@ -122,6 +128,14 @@ class StateStatistics():
 
         stat_str += "-----------    ATD    -----------\n"
         stat_str += f"{results['loss']: .3g}\n\n"
+
+        stat_str += f"Time to discovery:\n\n"
+        stat_str += f"    row   : value\n"
+
+        for i, v in results['time_to_discovery'].items():
+            stat_str += f"    {i: <6}: {v}\n"
+
+        stat_str += "\n\n"
 
         if len(results["wss"]) + len(results["rrf"]) > 0:
             stat_str += "-----------  WSS/RRF  -----------\n"


### PR DESCRIPTION
```
jonathan$ python -m asreview stat tests/output/ptsd.h5
************  ptsd.h5  *******************

-----------  general  -----------
Number of runs            : 1
Number of papers          : 6189
Number of included papers : 43
Number of excluded papers : 6146
Number of unlabeled papers: 0
Number of queries         : 6188

-----------  settings  -----------
model             : nb
query_strategy    : max
balance_strategy  : double
feature_extraction: tfidf
n_instances       : 1
n_prior_included  : 1
n_prior_excluded  : 1
mode              : simulate
model_param       : {'alpha': 3.822}
query_param       : {}
feature_param     : {'ngram_max': 1, 'stop_words': 'english', 'split_ta': 0, 'use_keywords': 0}
balance_param     : {'a': 2.155, 'alpha': 0.94, 'b': 0.789, 'beta': 1.0}
abstract_only     : False

-----------    ATD    -----------
 0.0165

Time to discovery:

    row   : value
    3898  : 22.0
    675   : 23.0
    284   : 24.0
    592   : 25.0
    1446  : 29.0
    335   : 31.0
    5054  : 40.0
    5244  : 46.0
    4011  : 47.0
    2408  : 50.0
    719   : 51.0
    720   : 52.0
    1568  : 63.0
    2472  : 70.0
    1425  : 73.0
    896   : 79.0
    897   : 81.0
    3489  : 84.0
    2455  : 91.0
    4250  : 93.0
    3053  : 95.0
    4435  : 97.0
    4434  : 98.0
    2616  : 100.0
    4334  : 102.0
    3141  : 103.0
    4938  : 108.0
    4939  : 110.0
    5284  : 115.0
    1933  : 118.0
    4313  : 122.0
    5655  : 130.0
    2446  : 132.0
    2445  : 133.0
    2444  : 134.0
    2382  : 140.0
    4768  : 148.0
    1922  : 151.0
    4104  : 157.0
    3483  : 169.0
    5479  : 234.0
    3316  : 523.0


-----------  WSS/RRF  -----------
WSS@95 : 92.51 %
WSS@100: 91.55 %
RRF@5  : 97.62 %
RRF@10 : 100.00 %
```