### PR TITLE
Include additional badges in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ASReview-statistics
 
-[![PyPI version](https://badge.fury.io/py/asreview-statistics.svg)](https://badge.fury.io/py/asreview-statistics)[![Downloads](https://pepy.tech/badge/asreview-statistics)](https://pepy.tech/project/asreview-statistics)![PyPI - License](https://img.shields.io/pypi/l/asreview-statistics)![Deploy and release](https://github.com/asreview/asreview-statistics/workflows/Deploy%20and%20release/badge.svg)![Build status](https://github.com/asreview/asreview-statistics/workflows/test-suite/badge.svg)
+[![PyPI version](https://badge.fury.io/py/asreview-statistics.svg)](https://badge.fury.io/py/asreview-statistics) [![Downloads](https://pepy.tech/badge/asreview-statistics)](https://pepy.tech/project/asreview-statistics) ![PyPI - License](https://img.shields.io/pypi/l/asreview-statistics) ![Deploy and release](https://github.com/asreview/asreview-statistics/workflows/Deploy%20and%20release/badge.svg) ![Build status](https://github.com/asreview/asreview-statistics/workflows/test-suite/badge.svg)
 
 ASReview extension for generating statistics on state files and datasets.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ASReview-statistics
 
-![Deploy and release](https://github.com/asreview/asreview-statistics/workflows/Deploy%20and%20release/badge.svg)![Build status](https://github.com/asreview/asreview-statistics/workflows/test-suite/badge.svg)
+[![PyPI version](https://badge.fury.io/py/asreview-statistics.svg)](https://badge.fury.io/py/asreview-statistics)[![Downloads](https://pepy.tech/badge/asreview-statistics)](https://pepy.tech/project/asreview-statistics)![PyPI - License](https://img.shields.io/pypi/l/asreview-statistics)![Deploy and release](https://github.com/asreview/asreview-statistics/workflows/Deploy%20and%20release/badge.svg)![Build status](https://github.com/asreview/asreview-statistics/workflows/test-suite/badge.svg)
 
 ASReview extension for generating statistics on state files and datasets.
 


### PR DESCRIPTION
This PR includes the PyPi, number of downloads and license as badges. Adding the badges helps with visibility of the package and therefore increase traffic. 